### PR TITLE
Php53

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 php:
   - 5.5
   - 5.4
+  - 5.3
   - hhvm
 
 matrix:

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
       "zendframework/zend-modulemanager": "2.*",
       "zendframework/zend-servicemanager": "2.*",
       "zendframework/zend-stdlib": "2.*",
-      "doctrine/doctrine-module": ">=0.8.0"
+      "doctrine/doctrine-module": ">=0.8.0",
+      "doctrine/instantiator": "~1.0.4"
     },
     "require-dev": {
       "fabpot/PHP-CS-Fixer": "*",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-      "php": ">=5.4.0",
+      "php": ">=5.3.23",
       "doctrine/common": ">=2.1",
       "zendframework/zend-modulemanager": "2.*",
       "zendframework/zend-servicemanager": "2.*",

--- a/src/Hydrator/ODM/MongoDB/DoctrineObject.php
+++ b/src/Hydrator/ODM/MongoDB/DoctrineObject.php
@@ -41,7 +41,7 @@ class DoctrineObject extends BaseHydrator
             }
 
             $fieldMeta = $this->metadata->fieldMappings[$field];
-            if (in_array($fieldMeta['type'], ['date', 'timestamp'])) {
+            if (in_array($fieldMeta['type'], array('date', 'timestamp'))) {
                 $isTimestamp = ($fieldMeta['type'] == 'timestamp');
                 $this->addStrategy($field, new DateTimeField($isTimestamp));
             }

--- a/src/Hydrator/ODM/MongoDB/Strategy/AbstractMongoStrategy.php
+++ b/src/Hydrator/ODM/MongoDB/Strategy/AbstractMongoStrategy.php
@@ -4,7 +4,6 @@ namespace Phpro\DoctrineHydrationModule\Hydrator\ODM\MongoDB\Strategy;
 
 use Doctrine\Common\Persistence\ObjectManager;
 use DoctrineModule\Persistence\ObjectManagerAwareInterface;
-use DoctrineModule\Persistence\ProvidesObjectManager;
 use DoctrineModule\Stdlib\Hydrator\Strategy\AbstractCollectionStrategy;
 use DoctrineModule\Stdlib\Hydrator\Strategy\AllowRemoveByValue;
 use Phpro\DoctrineHydrationModule\Hydrator\ODM\MongoDB\DoctrineObject;
@@ -18,7 +17,30 @@ abstract class AbstractMongoStrategy
     extends AbstractCollectionStrategy
     implements ObjectManagerAwareInterface
 {
-    use ProvidesObjectManager;
+    /**
+     * @var ObjectManager
+     */
+    protected $objectManager;
+
+    /**
+     * Set the object manager
+     *
+     * @param ObjectManager $objectManager
+     */
+    public function setObjectManager(ObjectManager $objectManager)
+    {
+        $this->objectManager = $objectManager;
+    }
+
+    /**
+     * Get the object manager
+     *
+     * @return ObjectManager
+     */
+    public function getObjectManager()
+    {
+        return $this->objectManager;
+    }
 
     /**
      *

--- a/src/Hydrator/ODM/MongoDB/Strategy/EmbeddedCollection.php
+++ b/src/Hydrator/ODM/MongoDB/Strategy/EmbeddedCollection.php
@@ -8,6 +8,7 @@ namespace Phpro\DoctrineHydrationModule\Hydrator\ODM\MongoDB\Strategy;
 
 use Doctrine\Common\Collections\Collection;
 use DoctrineModule\Stdlib\Hydrator;
+use Doctrine\Instantiator\Instantiator;
 
 /**
  * Class PersistentCollection
@@ -92,8 +93,8 @@ class EmbeddedCollection extends AbstractMongoStrategy
             return $document;
         }
 
-        $rc = new \ReflectionClass($targetDocument);
-        $object = $rc->newInstance();
+        $instantiator = new Instantiator();
+        $object = $instantiator->instantiate($targetDocument);
 
         $hydrator = $this->getDoctrineHydrator($targetDocument);
         $hydrator->hydrate($document, $object);

--- a/src/Hydrator/ODM/MongoDB/Strategy/EmbeddedCollection.php
+++ b/src/Hydrator/ODM/MongoDB/Strategy/EmbeddedCollection.php
@@ -93,7 +93,7 @@ class EmbeddedCollection extends AbstractMongoStrategy
         }
 
         $rc = new \ReflectionClass($targetDocument);
-        $object = $rc->newInstanceWithoutConstructor();
+        $object = $rc->newInstance();
 
         $hydrator = $this->getDoctrineHydrator($targetDocument);
         $hydrator->hydrate($document, $object);

--- a/src/Hydrator/ODM/MongoDB/Strategy/EmbeddedCollection.php
+++ b/src/Hydrator/ODM/MongoDB/Strategy/EmbeddedCollection.php
@@ -30,7 +30,7 @@ class EmbeddedCollection extends AbstractMongoStrategy
         }
 
         $mapping = $this->getClassMetadata()->fieldMappings[$this->getCollectionName()];
-        $result = [];
+        $result = array();
         if ($value) {
             foreach ($value as $index => $object) {
                 $hydrator = $this->getDoctrineHydrator($object);

--- a/src/Hydrator/ODM/MongoDB/Strategy/EmbeddedField.php
+++ b/src/Hydrator/ODM/MongoDB/Strategy/EmbeddedField.php
@@ -6,6 +6,8 @@
 
 namespace Phpro\DoctrineHydrationModule\Hydrator\ODM\MongoDB\Strategy;
 
+use Doctrine\Instantiator\Instantiator;
+
 /**
  * Class PersistentCollection
  *
@@ -39,8 +41,8 @@ class EmbeddedField extends AbstractMongoStrategy
             return $value;
         }
 
-        $rc = new \ReflectionClass($targetDocument);
-        $object = $rc->newInstance();
+        $instantiator = new Instantiator();
+        $object = $instantiator->instantiate($targetDocument);
 
         $hydrator = $this->getDoctrineHydrator($targetDocument);
         $hydrator->hydrate($value, $object);

--- a/src/Hydrator/ODM/MongoDB/Strategy/EmbeddedField.php
+++ b/src/Hydrator/ODM/MongoDB/Strategy/EmbeddedField.php
@@ -40,7 +40,7 @@ class EmbeddedField extends AbstractMongoStrategy
         }
 
         $rc = new \ReflectionClass($targetDocument);
-        $object = $rc->newInstanceWithoutConstructor();
+        $object = $rc->newInstance();
 
         $hydrator = $this->getDoctrineHydrator($targetDocument);
         $hydrator->hydrate($value, $object);

--- a/src/Hydrator/ODM/MongoDB/Strategy/ReferencedCollection.php
+++ b/src/Hydrator/ODM/MongoDB/Strategy/ReferencedCollection.php
@@ -29,7 +29,7 @@ class ReferencedCollection extends AbstractMongoStrategy
         $strategy->setClassMetadata($this->getClassMetadata());
         $strategy->setCollectionName($this->getCollectionName());
 
-        $result = [];
+        $result = array();
         if ($value) {
             foreach ($value as $key => $record) {
                 $strategy->setObject($record);

--- a/src/Service/DoctrineHydratorFactory.php
+++ b/src/Service/DoctrineHydratorFactory.php
@@ -294,10 +294,10 @@ class DoctrineHydratorFactory implements AbstractFactoryInterface
         }
 
         foreach ($config['filters'] as $name => $filterConfig) {
-            $conditionMap = [
+            $conditionMap = array(
                 'and' => FilterComposite::CONDITION_AND,
                 'or'  => FilterComposite::CONDITION_OR,
-            ];
+            );
             $condition = isset($filterConfig['condition']) ?
                             $conditionMap[$filterConfig['condition']] :
                             FilterComposite::CONDITION_OR;

--- a/test/config/module.config.php
+++ b/test/config/module.config.php
@@ -7,15 +7,15 @@ return array(
             'by_value' => true,
             'use_generated_hydrator' => false,
             'naming_strategy' => 'custom.naming_strategy',
-            'strategies' => [
+            'strategies' => array(
                 'fieldname' => 'custom.strategy',
-            ],
-            'filters' => [
-                'custom.filter.name' => [
+            ),
+            'filters' => array(
+                'custom.filter.name' => array(
                     'condition' => 'and', //FilterComposite::CONDITION_AND,
                     'filter' => 'custom.filter',
-                ],
-            ],
+                ),
+            ),
         ),
     ),
 );

--- a/test/src/Bootstrap.php
+++ b/test/src/Bootstrap.php
@@ -49,9 +49,9 @@ class Bootstrap
         $this->autoLoader->addPsr4('PhproTest\\DoctrineHydrationModule\\Tests\\', __DIR__.'/Tests/');
         $this->autoLoader->addPsr4('PhproTest\\DoctrineHydrationModule\\Fixtures\\', __DIR__.'/Fixtures/');
 
-        $this->autoLoader->addClassMap([
+        $this->autoLoader->addClassMap(array(
             'Doctrine\\ODM\\MongoDB\\Tests\\BaseTest' => PROJECT_BASE_PATH.'/vendor/doctrine/mongodb-odm/tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php',
-        ]);
+        ));
     }
 
     /**

--- a/test/src/Tests/Hydrator/DoctrineHydratorTest.php
+++ b/test/src/Tests/Hydrator/DoctrineHydratorTest.php
@@ -58,7 +58,7 @@ class DoctrineHydratorTest extends \PHPUnit_Framework_TestCase
     public function it_should_extract_an_object()
     {
         $object = new \stdClass();
-        $extracted = ['extracted' => true];
+        $extracted = array('extracted' => true);
         $extractService = $this->getMock('Zend\Stdlib\Hydrator\HydratorInterface');
         $extractService
             ->expects($this->any())
@@ -77,7 +77,7 @@ class DoctrineHydratorTest extends \PHPUnit_Framework_TestCase
     public function it_should_hydrate_an_object()
     {
         $object = new \stdClass();
-        $data = ['field' => 'value'];
+        $data = array('field' => 'value');
 
         $hydrateService = $this->getMock('Zend\Stdlib\Hydrator\HydratorInterface');
         $hydrateService
@@ -98,7 +98,7 @@ class DoctrineHydratorTest extends \PHPUnit_Framework_TestCase
     public function it_should_use_a_generated_doctrine_hydrator_while_hydrating_an_object()
     {
         $object = new \stdClass();
-        $data = ['field' => 'value'];
+        $data = array('field' => 'value');
 
         $hydrateService = $this->getMock('Doctrine\ODM\MongoDB\Hydrator\HydratorInterface');
         $hydrateService

--- a/test/src/Tests/Hydrator/ODM/MongoDB/DoctrineObjectTest.php
+++ b/test/src/Tests/Hydrator/ODM/MongoDB/DoctrineObjectTest.php
@@ -24,7 +24,7 @@ class DoctrineObjectTest extends BaseTest
      */
     protected function createHydrator($objectManager = null)
     {
-        $objectManager = $objectManager ? $objectManager : $this->getMock('Doctrine\ODM\MongoDB\DocumentManager', [], [], '', false);
+        $objectManager = $objectManager ? $objectManager : $this->getMock('Doctrine\ODM\MongoDB\DocumentManager', array(), array(), '', false);
         $hydrator = new DoctrineObject($objectManager);
 
         return $hydrator;
@@ -70,7 +70,7 @@ class DoctrineObjectTest extends BaseTest
         $embedMany = new HydrationEmbedMany();
         $embedMany->setId(1);
         $embedMany->setName('name');
-        $user->addEmbedMany([$embedMany]);
+        $user->addEmbedMany(array($embedMany));
 
         $referenceOne = new HydrationReferenceOne();
         $referenceOne->setId(1);
@@ -80,7 +80,7 @@ class DoctrineObjectTest extends BaseTest
         $referenceMany = new HydrationEmbedMany();
         $referenceMany->setId(1);
         $referenceMany->setName('name');
-        $user->addReferenceMany([$referenceMany]);
+        $user->addReferenceMany(array($referenceMany));
 
         $hydrator = new DoctrineObject($this->dm);
         $result = $hydrator->extract($user);
@@ -106,24 +106,24 @@ class DoctrineObjectTest extends BaseTest
         $birthday = new \DateTime('1 january 2014');
 
         $user = new HydrationUser();
-        $data = [
+        $data = array(
             'id' => 1,
             'name' => 'user',
             'creationDate' => $creationDate->getTimestamp(),
             'birthday' => $birthday->getTimestamp(),
             'referenceOne' => $this->createReferenceOne('name'),
-            'referenceMany' => [$this->createReferenceMany('name')],
-            'embedOne' => [
+            'referenceMany' => array($this->createReferenceMany('name')),
+            'embedOne' => array(
                 'id' => 1,
                 'name' => 'name',
-            ],
-            'embedMany' => [
-                [
+            ),
+            'embedMany' => array(
+                array(
                     'id' => 1,
                     'name' => 'name',
-                ],
-            ],
-        ];
+                ),
+            ),
+        );
 
         $hydrator = new DoctrineObject($this->dm);
         $hydrator->hydrate($data, $user);
@@ -133,13 +133,15 @@ class DoctrineObjectTest extends BaseTest
         $this->assertEquals($creationDate->getTimestamp(), $user->getCreatedAt());
         $this->assertEquals($birthday->getTimestamp(), $user->getBirthday()->getTimestamp());
         $this->assertInstanceOf('PhproTest\DoctrineHydrationModule\Fixtures\ODM\MongoDb\HydrationReferenceOne', $user->getReferenceOne());
-        $this->assertInstanceOf('PhproTest\DoctrineHydrationModule\Fixtures\ODM\MongoDb\HydrationReferenceMany', $user->getReferenceMany()[0]);
+        $referenceMany = $user->getReferenceMany();
+        $this->assertInstanceOf('PhproTest\DoctrineHydrationModule\Fixtures\ODM\MongoDb\HydrationReferenceMany', $referenceMany[0]);
         $this->assertInstanceOf('PhproTest\DoctrineHydrationModule\Fixtures\ODM\MongoDb\HydrationEmbedOne', $user->getEmbedOne());
-        $this->assertInstanceOf('PhproTest\DoctrineHydrationModule\Fixtures\ODM\MongoDb\HydrationEmbedMany', $user->getEmbedMany()[0]);
+        $embedMany = $user->getEmbedMany();
+        $this->assertInstanceOf('PhproTest\DoctrineHydrationModule\Fixtures\ODM\MongoDb\HydrationEmbedMany', $embedMany[0]);
         $this->assertEquals('name', $user->getReferenceOne()->getName());
-        $this->assertEquals('name', $user->getReferenceMany()[0]->getName());
+        $this->assertEquals('name', $referenceMany[0]->getName());
         $this->assertEquals('name', $user->getEmbedOne()->getName());
-        $this->assertEquals('name', $user->getEmbedMany()[0]->getName());
+        $this->assertEquals('name', $embedMany[0]->getName());
     }
 
     /**

--- a/test/src/Tests/Hydrator/ODM/MongoDB/Strategy/DefaultRelation.php
+++ b/test/src/Tests/Hydrator/ODM/MongoDB/Strategy/DefaultRelation.php
@@ -1,10 +1,10 @@
 <?php
 
 namespace PhproTest\DoctrineHydrationModule\Tests\Hydrator\ODM\MongoDB\Strategy;
-use Phpro\DoctrineHydrationModule\Hydrator\ODM\MongoDB\Strategy\DefaultRelation;
+
+use Phpro\DoctrineHydrationModule\Hydrator\ODM\MongoDB\Strategy\DefaultRelation as StrategyDefaultRelation;
 use PhproTest\DoctrineHydrationModule\Fixtures\ODM\MongoDb\HydrationUser;
 use Zend\Stdlib\Hydrator\Strategy\StrategyInterface;
-
 
 /**
  * Class EmbeddedFieldTest
@@ -18,7 +18,7 @@ class DefaultRelation extends AbstractMongoStrategyTest
      */
     protected function createStrategy()
     {
-        return new DefaultRelation();
+        return new StrategyDefaultRelation();
     }
 
     /**
@@ -33,7 +33,7 @@ class DefaultRelation extends AbstractMongoStrategyTest
         $embedded = new HydrationEmbedMany();
         $embedded->setId(1);
         $embedded->setName('name');
-        $user->addEmbedMany([$embedded]);
+        $user->addEmbedMany(array($embedded));
 
         $strategy = $this->getStrategy($this->dm, $user, 'embedMany');
         $result = $strategy->extract($user->getEmbedMany());
@@ -49,15 +49,16 @@ class DefaultRelation extends AbstractMongoStrategyTest
         $user->setId(1);
         $user->setName('username');
 
-        $data = [
-            [
+        $data = array(
+            array(
                 'id' => 1,
-                'name' => 'name'
-            ]
-        ];
+                'name' => 'name',
+            ),
+        );
 
         $strategy = $this->getStrategy($this->dm, $user, 'embedMany');
         $strategy->hydrate($data);
-        $this->assertEquals('name', $user->getEmbedMany()[0]->getName());
+        $embedMany = $user->getEmbedMany();
+        $this->assertEquals('name', $embedMany[0]->getName());
     }
 }

--- a/test/src/Tests/Hydrator/ODM/MongoDB/Strategy/EmbeddedCollectionTest.php
+++ b/test/src/Tests/Hydrator/ODM/MongoDB/Strategy/EmbeddedCollectionTest.php
@@ -35,7 +35,7 @@ class EmbeddedCollectionTest extends AbstractMongoStrategyTest
         $embedded = new HydrationEmbedMany();
         $embedded->setId(1);
         $embedded->setName('name');
-        $user->addEmbedMany([$embedded]);
+        $user->addEmbedMany(array($embedded));
 
         $strategy = $this->getStrategy($this->dm, $user, 'embedMany');
         $result = $strategy->extract($user->getEmbedMany());
@@ -51,16 +51,17 @@ class EmbeddedCollectionTest extends AbstractMongoStrategyTest
         $user->setId(1);
         $user->setName('username');
 
-        $data = [
-            [
+        $data = array(
+            array(
                 'id' => 1,
                 'name' => 'name',
-            ],
-        ];
+            ),
+        );
 
         $strategy = $this->getStrategy($this->dm, $user, 'embedMany');
         $strategy->hydrate($data);
-        $this->assertEquals('name', $user->getEmbedMany()[0]->getName());
+        $embedMany = $user->getEmbedMany();
+        $this->assertEquals('name', $embedMany[0]->getName());
     }
 
     /**
@@ -72,12 +73,12 @@ class EmbeddedCollectionTest extends AbstractMongoStrategyTest
         $user->setId(1);
         $user->setName('username');
 
-        $data = [
-            'user1' => [
+        $data = array(
+            'user1' => array(
                 'id' => 1,
                 'name' => 'name',
-            ],
-        ];
+            ),
+        );
 
         $strategy = $this->getStrategy($this->dm, $user, 'embedMany');
         $strategy->hydrate($data);

--- a/test/src/Tests/Hydrator/ODM/MongoDB/Strategy/EmbeddedFieldTest.php
+++ b/test/src/Tests/Hydrator/ODM/MongoDB/Strategy/EmbeddedFieldTest.php
@@ -50,10 +50,10 @@ class EmbeddedFieldTest extends AbstractMongoStrategyTest
         $user->setId(1);
         $user->setName('username');
 
-        $data = [
+        $data = array(
             'id' => 1,
             'name' => 'name',
-        ];
+        );
 
         $strategy = $this->getStrategy($this->dm, $user, 'embedOne');
         $result = $strategy->hydrate($data);

--- a/test/src/Tests/Hydrator/ODM/MongoDB/Strategy/EmbeddedReferenceCollectionTest.php
+++ b/test/src/Tests/Hydrator/ODM/MongoDB/Strategy/EmbeddedReferenceCollectionTest.php
@@ -34,7 +34,7 @@ class EmbeddedReferenceCollectionTest extends AbstractMongoStrategyTest
         $referenced = new HydrationReferenceMany();
         $referenced->setId(1);
         $referenced->setName('name');
-        $user->addReferenceMany([$referenced]);
+        $user->addReferenceMany(array($referenced));
 
         $strategy = $this->getStrategy($this->dm, $user, 'referenceMany');
         $result = $strategy->extract($user->getReferenceMany());
@@ -51,11 +51,12 @@ class EmbeddedReferenceCollectionTest extends AbstractMongoStrategyTest
         $user->setName('username');
 
         $id = $this->createReference('name');
-        $data = [$id];
+        $data = array($id);
 
         $strategy = $this->getStrategy($this->dm, $user, 'referenceMany');
         $strategy->hydrate($data);
-        $this->assertEquals('name', $user->getReferenceMany()[0]->getName());
+        $referenceMany = $user->getReferenceMany();
+        $this->assertEquals('name', $referenceMany[0]->getName());
     }
 
     /**

--- a/test/src/Tests/Hydrator/ODM/MongoDB/Strategy/ReferencedCollectionTest.php
+++ b/test/src/Tests/Hydrator/ODM/MongoDB/Strategy/ReferencedCollectionTest.php
@@ -34,7 +34,7 @@ class ReferencedCollectionTest extends AbstractMongoStrategyTest
         $referenced = new HydrationReferenceMany();
         $referenced->setId(1);
         $referenced->setName('name');
-        $user->addReferenceMany([$referenced]);
+        $user->addReferenceMany(array($referenced));
 
         $strategy = $this->getStrategy($this->dm, $user, 'referenceMany');
         $result = $strategy->extract($user->getReferenceMany());
@@ -51,11 +51,12 @@ class ReferencedCollectionTest extends AbstractMongoStrategyTest
         $user->setName('username');
 
         $id = $this->createReference('name');
-        $data = [$id];
+        $data = array($id);
 
         $strategy = $this->getStrategy($this->dm, $user, 'referenceMany');
         $strategy->hydrate($data);
-        $this->assertEquals('name', $user->getReferenceMany()[0]->getName());
+        $referenceMany = $user->getReferenceMany();
+        $this->assertEquals('name', $referenceMany[0]->getName());
     }
 
     /**

--- a/test/src/Tests/Service/DoctrineHydratorFactoryTest.php
+++ b/test/src/Tests/Service/DoctrineHydratorFactoryTest.php
@@ -56,7 +56,7 @@ class DoctrineHydratorFactoryTest extends \PHPUnit_Framework_TestCase
      */
     protected function stubObjectManager($objectManagerClass)
     {
-        $objectManager = $this->getMock($objectManagerClass, [], [], '', false);
+        $objectManager = $this->getMock($objectManagerClass, array(), array(), '', false);
         $this->serviceManager->setService('doctrine.default.object-manager', $objectManager);
 
         return $objectManager;
@@ -154,7 +154,7 @@ class DoctrineHydratorFactoryTest extends \PHPUnit_Framework_TestCase
         $this->serviceManager->setService('Config', $this->serviceConfig);
         $objectManager = $this->stubObjectManager('Doctrine\ODM\MongoDb\DocumentManager');
 
-        $hydratorFactory = $this->getMock('Doctrine\ODM\MongoDB\Hydrator\HydratorFactory', [], [], '', false);
+        $hydratorFactory = $this->getMock('Doctrine\ODM\MongoDB\Hydrator\HydratorFactory', array(), array(), '', false);
         $generatedHydrator = $this->getMock('Doctrine\ODM\MongoDB\Hydrator\HydratorInterface');
 
         $objectManager


### PR DESCRIPTION
Per #14 this gives backwards compatibility to PHP 5.3.  

Two commits here, the second one I need your eye for.  PHP 5.3 does not support ReflectionInstance::newInstanceWithoutConstructor.  5.3 unit tests pass with my change but I don't know all the consequences of this change.  Could we do the same thing with https://github.com/Ocramius/Instantiator ?