### PR TITLE
Added configuration to override the base hydrator (DoctrineObject), refa...

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,22 +58,10 @@ Strategies will not work when this option is set to `true`.
 
 From here on, you can get the hydrator by calling `get('hydrator-manager-key')` on the HydratorManager.
 
-#Override hydrator:
+# Custom strategies:
 
-If the standard DoctrineHydrator is not flexible enough, you can set a custom `hydrator`. This allows you to use an extended DoctrineHydrator or another existing hydrator, and configure it with this module. This setting will override `use_generated_hydrator`.
-
-```php
-return array(
-    'doctrine-hydrator' => array(
-        'custom-hydrator' => array(
-            // other config
-            'hydrator' => 'Zend\Stdlib\Hydrator\ArraySerializable'
-        ),
-    ),
-);
-
-#Custom strategies:
 ## MongoDB ODM
+
 - DateTimeField: Used for DateTime objects
 - DefaultRelation: Leave the relation AS-IS. Does not perform any modifications on the field.
 - EmbeddedCollection: Used for embedded collections
@@ -83,7 +71,7 @@ return array(
 - EmbeddedReferenceCollection: This is a custom strategy that can be used in an API to display all fields in a referenced object. The hydration works as a regular referenced object.
 - EmbeddedReferenceField: This is a custom strategy that can be used in an API to display all fields in a referenced object. The hydration works as a regular referenced object.
 
-#Custom Filters
+# Custom Filters
 
 Custom filters allow you to fine-tune the results of the hydrator's `extract` functionality by determining which fields should be extracted. 
 
@@ -107,6 +95,22 @@ return array(
 In this example configuration, the hydrator factory will retrieve `custom.filter` from the Service Manager and inject it as a filter into the hydrator. The filter must implement `Zend\Stdlib\Hydrator\Filter\FilterInterface`. 
 
 The service's `filter($fieldName)` function will be called by the hydrator during `extract` and the field name being extracted will be passed as an argument. The `filter()` function must return a truthy value: if `true` then the field will NOT be extracted.
+
+
+# Override hydrator:
+
+If the standard DoctrineHydrator is not flexible enough, you can set a custom `hydrator`. This allows you to use an extended DoctrineHydrator or another existing hydrator, and configure it with this module. This setting will override `use_generated_hydrator`.
+
+```php
+return array(
+    'doctrine-hydrator' => array(
+        'custom-hydrator' => array(
+            // other config
+            'hydrator' => 'Zend\Stdlib\Hydrator\ArraySerializable'
+        ),
+    ),
+);
+```
 
 # Testing
 This package is fully tested with Cs fixer and PhpUnit. The MongoDB tests require mongodb to be installed on your machine. You can skip these tests by adding a testsuite to the command:

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ return array(
             'by_value' => true,
             'use_generated_hydrator' => true,
             'naming_strategy' => 'custom.naming.strategy.key.in.servicemanager',
+            'hydrator' => 'custom.hydrator.key.in.hydratormanager',
             'strategies' => [
                 'fieldname' => 'custom.strategy.key.in.servicemanager',
             ],
@@ -56,6 +57,20 @@ Strategies will not work when this option is set to `true`.
 
 
 From here on, you can get the hydrator by calling `get('hydrator-manager-key')` on the HydratorManager.
+
+#Override hydrator:
+
+If the standard DoctrineHydrator is not flexible enough, you can set a custom `hydrator`. This allows you to use an extended DoctrineHydrator or another existing hydrator, and configure it with this module. This setting will override `use_generated_hydrator`.
+
+```php
+return array(
+    'doctrine-hydrator' => array(
+        'custom-hydrator' => array(
+            // other config
+            'hydrator' => 'Zend\Stdlib\Hydrator\ArraySerializable'
+        ),
+    ),
+);
 
 #Custom strategies:
 ## MongoDB ODM
@@ -87,6 +102,7 @@ return array(
         ),
     ),
 );
+
 ```
 In this example configuration, the hydrator factory will retrieve `custom.filter` from the Service Manager and inject it as a filter into the hydrator. The filter must implement `Zend\Stdlib\Hydrator\Filter\FilterInterface`. 
 

--- a/src/Service/DoctrineHydratorFactory.php
+++ b/src/Service/DoctrineHydratorFactory.php
@@ -117,7 +117,7 @@ class DoctrineHydratorFactory implements AbstractFactoryInterface
 
         $extractService = null;
         $hydrateService = null;
-        
+
         $useEntityHydrator = (array_key_exists('use_generated_hydrator', $config) && $config['use_generated_hydrator']);
         $useCustomHydrator = (array_key_exists('hydrator', $config));
 

--- a/test/src/Tests/Service/DoctrineHydratorFactoryTest.php
+++ b/test/src/Tests/Service/DoctrineHydratorFactoryTest.php
@@ -176,7 +176,6 @@ class DoctrineHydratorFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($generatedHydrator, $hydrator->getHydrateService());
     }
 
-
     /**
      * @test
      */
@@ -190,7 +189,7 @@ class DoctrineHydratorFactoryTest extends \PHPUnit_Framework_TestCase
             ->method('get')
             ->with('custom.hydrator')
             ->will($this->returnValue($this->getMock('Zend\Stdlib\Hydrator\ArraySerializable')));
-        
+
         $hydrator = $this->createOrmHydrator();
 
         $this->assertInstanceOf('Zend\Stdlib\Hydrator\ArraySerializable', $hydrator->getHydrateService());

--- a/test/src/Tests/Service/DoctrineHydratorFactoryTest.php
+++ b/test/src/Tests/Service/DoctrineHydratorFactoryTest.php
@@ -176,6 +176,27 @@ class DoctrineHydratorFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($generatedHydrator, $hydrator->getHydrateService());
     }
 
+
+    /**
+     * @test
+     */
+    public function it_should_be_possible_to_configure_a_custom_hydrator()
+    {
+        $this->serviceConfig['doctrine-hydrator']['custom-hydrator']['hydrator'] = 'custom.hydrator';
+        $this->serviceManager->setService('Config', $this->serviceConfig);
+
+        $this->hydratorManager
+            ->expects($this->once())
+            ->method('get')
+            ->with('custom.hydrator')
+            ->will($this->returnValue($this->getMock('Zend\Stdlib\Hydrator\ArraySerializable')));
+        
+        $hydrator = $this->createOrmHydrator();
+
+        $this->assertInstanceOf('Zend\Stdlib\Hydrator\ArraySerializable', $hydrator->getHydrateService());
+        $this->assertInstanceOf('Zend\Stdlib\Hydrator\ArraySerializable', $hydrator->getExtractService());
+    }
+
     /**
      * @test
      */


### PR DESCRIPTION
- Refactored createServiceWithName.  
  Now all hydrators will be configured for filters, strategies and namingStrategy, not only DoctrineHydrator.
- Added configuration option to override the hydrator (so you can extend the default hydrator, or replace it)

This time tests included :)