### PR TITLE
Remove document from getDoctrineHydrator

### DIFF
--- a/src/Hydrator/ODM/MongoDB/Strategy/AbstractMongoStrategy.php
+++ b/src/Hydrator/ODM/MongoDB/Strategy/AbstractMongoStrategy.php
@@ -51,19 +51,11 @@ abstract class AbstractMongoStrategy
     }
 
     /**
-     * @param $document
-     *
      * @return DoctrineObject
      */
-    protected function getDoctrineHydrator($document)
+    protected function getDoctrineHydrator()
     {
-        if (is_object($document)) {
-            $document = get_class($document);
-        }
-
-        $hydrator = new DoctrineObject($this->getObjectManager(), $document);
-
-        return $hydrator;
+        return new DoctrineObject($this->getObjectManager());
     }
 
     /**


### PR DESCRIPTION
This code doesn't make any sense. The constructor for `DoctrineObject` takes an `ObjectManager` and a boolean. Why, then, are you passing a string class name to the second parameter? Presumably there can be no good reason.

Moreover, this method is still bad because you're invoking a concrete instance of `DoctrineObject` for recursive hydration even though that instance will be different to the original hydrator and may exhibit different behaviour. If you want to do recursive hydration, why not pass the original hydrator instance?