### PR TITLE
ZF3 Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
   "require": {
     "php": "^5.6 || ^7.0",
     "doctrine/common": "^2.6.1",
-    "zendframework/zend-servicemanager": "^2.7.6 || ^3.1.1",
+    "zendframework/zend-servicemanager": "^2.7.6 || ^3.1",
     "zendframework/zend-hydrator": "^1.1 || ^2.2.1",
     "api-skeletons/zf-doctrine-module-zend-hydrator": "^1.0",
     "doctrine/doctrine-module": "dev-master as 1.0",

--- a/composer.json
+++ b/composer.json
@@ -1,40 +1,56 @@
 {
-    "name": "phpro/zf-doctrine-hydration-module",
-    "license": "MIT",
-    "description": "Doctrine hydrators for ZF2",
-    "keywords": [
-        "zf2",
-        "doctrine",
-        "hydrator"
-    ],
-    "authors": [
-        {
-            "name": "Toon Verwerft",
-            "email": "toon.verwerft@phpro.be"
-        }
-    ],
-    "require": {
-        "php": ">=5.3.23",
-        "doctrine/common": "~2.1",
-        "zendframework/zend-modulemanager": "~2.0",
-        "zendframework/zend-servicemanager": "~2.0",
-        "zendframework/zend-hydrator": "~1.0 || ^2.0",
-        "api-skeletons/zf-doctrine-module-zend-hydrator": "^1.0",
-        "doctrine/doctrine-module": "~1.0",
-        "doctrine/instantiator": "~1.0.4"
-    },
-    "require-dev": {
-        "fabpot/PHP-CS-Fixer": "~1.10",
-        "phpunit/phpunit": "~4.8",
-        "doctrine/doctrine-orm-module": "~0.9",
-        "doctrine/doctrine-mongo-odm-module": "~0.9",
-        "doctrine/mongodb-odm": "~1.1",
-        "phpro/grumphp": "~0.7"
-    },
-    "autoload": {
-      "psr-4": {
-        "Phpro\\DoctrineHydrationModule\\": "src/",
-        "PhproTest\\DoctrineHydrationModule\\": "test/src/"
-      }
+  "name": "phpro/zf-doctrine-hydration-module",
+  "license": "MIT",
+  "description": "Doctrine hydrators for ZF2",
+  "keywords": [
+    "zf2",
+    "doctrine",
+    "hydrator"
+  ],
+  "authors": [
+    {
+      "name": "Toon Verwerft",
+      "email": "toon.verwerft@phpro.be"
     }
+  ],
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "https://github.com/webimpress/DoctrineModule"
+    },
+    {
+      "type": "vcs",
+      "url": "https://github.com/webimpress/DoctrineMongoODMModule"
+    },
+    {
+      "type": "vcs",
+      "url": "https://github.com/webimpress/DoctrineORMModule"
+    }
+  ],
+  "require": {
+    "php": "^5.6 || ^7.0",
+    "doctrine/common": "^2.6.1",
+    "zendframework/zend-servicemanager": "^2.7.6 || ^3.1.1",
+    "zendframework/zend-hydrator": "^1.1 || ^2.2.1",
+    "api-skeletons/zf-doctrine-module-zend-hydrator": "^1.0",
+    "doctrine/doctrine-module": "dev-feature/zf3compat as 1.0",
+    "doctrine/instantiator": "^1.0.5"
+  },
+  "require-dev": {
+    "fabpot/PHP-CS-Fixer": "^1.11.6",
+    "phpunit/phpunit": "^4.8",
+    "zendframework/zend-modulemanager": "^2.7.2",
+    "doctrine/doctrine-orm-module": "dev-feature/zf3compat",
+    "doctrine/doctrine-mongo-odm-module": "dev-feature/zf3compat",
+    "doctrine/mongodb-odm": "^1.1",
+    "phpro/grumphp": "^0.9.1"
+  },
+  "autoload": {
+    "psr-4": {
+      "Phpro\\DoctrineHydrationModule\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "PhproTest\\DoctrineHydrationModule\\": "test/src/"
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -16,15 +16,7 @@
   "repositories": [
     {
       "type": "vcs",
-      "url": "https://github.com/webimpress/DoctrineModule"
-    },
-    {
-      "type": "vcs",
       "url": "https://github.com/webimpress/DoctrineMongoODMModule"
-    },
-    {
-      "type": "vcs",
-      "url": "https://github.com/webimpress/DoctrineORMModule"
     }
   ],
   "require": {
@@ -33,14 +25,14 @@
     "zendframework/zend-servicemanager": "^2.7.6 || ^3.1.1",
     "zendframework/zend-hydrator": "^1.1 || ^2.2.1",
     "api-skeletons/zf-doctrine-module-zend-hydrator": "^1.0",
-    "doctrine/doctrine-module": "dev-feature/zf3compat as 1.0",
+    "doctrine/doctrine-module": "dev-master as 1.0",
     "doctrine/instantiator": "^1.0.5"
   },
   "require-dev": {
     "fabpot/PHP-CS-Fixer": "^1.11.6",
     "phpunit/phpunit": "^4.8",
     "zendframework/zend-modulemanager": "^2.7.2",
-    "doctrine/doctrine-orm-module": "dev-feature/zf3compat",
+    "doctrine/doctrine-orm-module": "dev-master",
     "doctrine/doctrine-mongo-odm-module": "dev-feature/zf3compat",
     "doctrine/mongodb-odm": "^1.1",
     "phpro/grumphp": "^0.9.1"

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "phpro/zf-doctrine-hydration-module",
   "license": "MIT",
-  "description": "Doctrine hydrators for ZF2",
+  "description": "Doctrine hydrators for ZF2 and ZF3",
   "keywords": [
     "zf2",
     "doctrine",

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     "doctrine/common": "^2.6.1",
     "zendframework/zend-servicemanager": "^2.7.6 || ^3.1",
     "zendframework/zend-hydrator": "^1.1 || ^2.2.1",
+    "zendframework/zend-modulemanager": "^2.7.2",
     "api-skeletons/zf-doctrine-module-zend-hydrator": "^1.0",
     "doctrine/doctrine-module": "^1.2",
     "doctrine/instantiator": "^1.0.5"
@@ -30,7 +31,6 @@
   "require-dev": {
     "fabpot/PHP-CS-Fixer": "^1.11.6",
     "phpunit/phpunit": "^4.8",
-    "zendframework/zend-modulemanager": "^2.7.2",
     "doctrine/doctrine-orm-module": "^1.1",
     "doctrine/doctrine-mongo-odm-module": "^0.11",
     "doctrine/mongodb-odm": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,8 @@
     }
   },
   "autoload-dev": {
-    "PhproTest\\DoctrineHydrationModule\\": "test/src/"
+    "psr-4": {
+      "PhproTest\\DoctrineHydrationModule\\": "test/src/"
+    }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,6 @@
       "email": "toon.verwerft@phpro.be"
     }
   ],
-  "repositories": [
-    {
-      "type": "vcs",
-      "url": "https://github.com/webimpress/DoctrineMongoODMModule"
-    }
-  ],
   "extra": {
     "zf": {
       "module": "Phpro\\DoctrineHydrationModule"
@@ -30,15 +24,15 @@
     "zendframework/zend-servicemanager": "^2.7.6 || ^3.1",
     "zendframework/zend-hydrator": "^1.1 || ^2.2.1",
     "api-skeletons/zf-doctrine-module-zend-hydrator": "^1.0",
-    "doctrine/doctrine-module": "dev-master as 1.0",
+    "doctrine/doctrine-module": "^1.2",
     "doctrine/instantiator": "^1.0.5"
   },
   "require-dev": {
     "fabpot/PHP-CS-Fixer": "^1.11.6",
     "phpunit/phpunit": "^4.8",
     "zendframework/zend-modulemanager": "^2.7.2",
-    "doctrine/doctrine-orm-module": "dev-master",
-    "doctrine/doctrine-mongo-odm-module": "dev-feature/zf3compat",
+    "doctrine/doctrine-orm-module": "^1.1",
+    "doctrine/doctrine-mongo-odm-module": "^0.11",
     "doctrine/mongodb-odm": "^1.1",
     "phpro/grumphp": "^0.9.1"
   },

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,11 @@
       "url": "https://github.com/webimpress/DoctrineMongoODMModule"
     }
   ],
+  "extra": {
+    "zf": {
+      "module": "Phpro\\DoctrineHydrationModule"
+    }
+  },
   "require": {
     "php": "^5.6 || ^7.0",
     "doctrine/common": "^2.6.1",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="./test/src/Bootstrap.php" colors="true">
     <testsuites>
         <testsuite name="Main">

--- a/src/Hydrator/DoctrineHydrator.php
+++ b/src/Hydrator/DoctrineHydrator.php
@@ -7,8 +7,7 @@ use Zend\Hydrator\HydratorInterface;
 /**
  * Class DoctrineHydrator.
  */
-class DoctrineHydrator
-    implements HydratorInterface
+class DoctrineHydrator implements HydratorInterface
 {
     /**
      * @var HydratorInterface
@@ -58,22 +57,22 @@ class DoctrineHydrator
         return $this->extractService->extract($object);
     }
 
-     /**
-      * Hydrate $object with the provided $data.
-      *
-      * @param array  $data
-      * @param object $object
-      *
-      * @return object
-      */
-     public function hydrate(array $data, $object)
-     {
-         // Zend hydrator:
+    /**
+     * Hydrate $object with the provided $data.
+     *
+     * @param array $data
+     * @param object $object
+     *
+     * @return object
+     */
+    public function hydrate(array $data, $object)
+    {
+        // Zend hydrator:
         if ($this->hydrateService instanceof HydratorInterface) {
             return $this->hydrateService->hydrate($data, $object);
         }
 
         // Doctrine hydrator: (parameters switched)
         return $this->hydrateService->hydrate($object, $data);
-     }
+    }
 }

--- a/src/Hydrator/ODM/MongoDB/Strategy/AbstractMongoStrategy.php
+++ b/src/Hydrator/ODM/MongoDB/Strategy/AbstractMongoStrategy.php
@@ -11,9 +11,7 @@ use Phpro\DoctrineHydrationModule\Hydrator\ODM\MongoDB\DoctrineObject;
 /**
  * Abstract AbstractMongoStrategy.
  */
-abstract class AbstractMongoStrategy
-    extends AbstractCollectionStrategy
-    implements ObjectManagerAwareInterface
+abstract class AbstractMongoStrategy extends AbstractCollectionStrategy implements ObjectManagerAwareInterface
 {
     /**
      * @var ObjectManager

--- a/src/Module.php
+++ b/src/Module.php
@@ -5,8 +5,7 @@ namespace Phpro\DoctrineHydrationModule;
 use Zend\ModuleManager\Feature\AutoloaderProviderInterface;
 use Zend\ModuleManager\Feature\ConfigProviderInterface;
 
-class Module
-    implements AutoloaderProviderInterface, ConfigProviderInterface
+class Module implements AutoloaderProviderInterface, ConfigProviderInterface
 {
     /**
      * @return array

--- a/test/src/Tests/Service/DoctrineHydratorFactoryTest.php
+++ b/test/src/Tests/Service/DoctrineHydratorFactoryTest.php
@@ -32,12 +32,15 @@ class DoctrineHydratorFactoryTest extends \PHPUnit_Framework_TestCase
 
         $this->serviceManager = new ServiceManager();
         $this->serviceManager->setAllowOverride(true);
-        $this->serviceManager->setService('Config', $this->serviceConfig);
+        $this->serviceManager->setService('config', $this->serviceConfig);
         $this->serviceManager->setService('custom.strategy', $this->getMock('Zend\Hydrator\Strategy\StrategyInterface'));
         $this->serviceManager->setService('custom.filter', $this->getMock('Zend\Hydrator\Filter\FilterInterface'));
         $this->serviceManager->setService('custom.naming_strategy', $this->getMock('Zend\Hydrator\NamingStrategy\NamingStrategyInterface'));
 
-        $this->hydratorManager = $this->getMock('Zend\Hydrator\HydratorPluginManager');
+        $this->hydratorManager = $this->getMockBuilder(HydratorPluginManager::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $this->hydratorManager
             ->expects($this->any())
             ->method('getServiceLocator')
@@ -146,7 +149,7 @@ class DoctrineHydratorFactoryTest extends \PHPUnit_Framework_TestCase
     public function it_should_create_a_custom_ODM_hydrator_which_uses_the_auto_generated_hydrators()
     {
         $this->serviceConfig['doctrine-hydrator']['custom-hydrator']['use_generated_hydrator'] = true;
-        $this->serviceManager->setService('Config', $this->serviceConfig);
+        $this->serviceManager->setService('config', $this->serviceConfig);
         $objectManager = $this->stubObjectManager('Doctrine\ODM\MongoDb\DocumentManager');
 
         $hydratorFactory = $this->getMock('Doctrine\ODM\MongoDB\Hydrator\HydratorFactory', array(), array(), '', false);
@@ -177,13 +180,9 @@ class DoctrineHydratorFactoryTest extends \PHPUnit_Framework_TestCase
     public function it_should_be_possible_to_configure_a_custom_hydrator()
     {
         $this->serviceConfig['doctrine-hydrator']['custom-hydrator']['hydrator'] = 'custom.hydrator';
-        $this->serviceManager->setService('Config', $this->serviceConfig);
+        $this->serviceManager->setService('config', $this->serviceConfig);
 
-        $this->hydratorManager
-            ->expects($this->once())
-            ->method('get')
-            ->with('custom.hydrator')
-            ->will($this->returnValue($this->getMock('Zend\Hydrator\ArraySerializable')));
+        $this->serviceManager->setService('custom.hydrator', $this->getMock('Zend\Hydrator\ArraySerializable'));
 
         $hydrator = $this->createOrmHydrator();
 


### PR DESCRIPTION
Added support for ZF3 modules. Only PHP5.6 and PHP7.0 are supported.
Depends on:
* ~~https://github.com/doctrine/DoctrineModule/pull/567~~ [DoctrineModule 1.2.0](https://github.com/doctrine/DoctrineModule/releases/tag/1.2.0)
* ~~https://github.com/doctrine/DoctrineMongoODMModule/pull/168~~ [DoctrineMongoODMModule 0.11.0](https://github.com/doctrine/DoctrineMongoODMModule/releases/tag/0.11.0)
* ~~https://github.com/doctrine/DoctrineORMModule/pull/493~~ [DoctrineORMModule 1.1.0](https://github.com/doctrine/DoctrineORMModule/releases/tag/1.1.0)