### PR TITLE
Use build instead of get to create a custom hydrator

### DIFF
--- a/src/Service/DoctrineHydratorFactory.php
+++ b/src/Service/DoctrineHydratorFactory.php
@@ -142,7 +142,7 @@ class DoctrineHydratorFactory implements AbstractFactoryInterface
         }
 
         if ($useCustomHydrator) {
-            $extractService = $container->get($config['hydrator']);
+            $extractService = $container->build($config['hydrator'], $config);
             $hydrateService = $extractService;
         }
 


### PR DESCRIPTION
Instead of configuring a custom hydrator for each hydrator configuration allow abstract-like factories to `build` the hydrator instead of a strait service manager `get`