### PR TITLE
Allow abstract factory for custom hydrator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   "require": {
     "php": "^5.6 || ^7.0",
     "doctrine/common": "^2.6.1",
-    "zendframework/zend-servicemanager": "^2.7.6 || ^3.1",
+    "zendframework/zend-servicemanager": "^3.3.2",
     "zendframework/zend-hydrator": "^1.1 || ^2.2.1",
     "zendframework/zend-modulemanager": "^2.7.2",
     "api-skeletons/zf-doctrine-module-zend-hydrator": "^1.0",

--- a/src/Service/DoctrineHydratorFactory.php
+++ b/src/Service/DoctrineHydratorFactory.php
@@ -142,7 +142,7 @@ class DoctrineHydratorFactory implements AbstractFactoryInterface
         }
 
         if ($useCustomHydrator) {
-            $extractService = $container->get($config['hydrator']);
+            $extractService = $container->build($config['hydrator'], $config);
             $hydrateService = $extractService;
         }
 

--- a/src/Service/DoctrineHydratorFactory.php
+++ b/src/Service/DoctrineHydratorFactory.php
@@ -142,7 +142,12 @@ class DoctrineHydratorFactory implements AbstractFactoryInterface
         }
 
         if ($useCustomHydrator) {
-            $extractService = $container->build($config['hydrator'], $config);
+            try {
+                $extractService = $container->build($config['hydrator'], $config);
+            } catch (ServiceNotFoundException $e) {
+                $extractService = $container->get($config['hydrator']);
+            }
+
             $hydrateService = $extractService;
         }
 

--- a/test/src/Hydrator/CustomBuildHydratorFactory.php
+++ b/test/src/Hydrator/CustomBuildHydratorFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace PhproTest\DoctrineHydrationModule\Hydrator;
+
+use Interop\Container\ContainerInterface;
+use Phpro\DoctrineHydrationModule\Hydrator\DoctrineHydrator;
+use Zend\Hydrator\ArraySerializable;
+
+final class CustomBuildHydratorFactory
+{
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        array $options = null
+    ) {
+        return new ArraySerializable();
+    }
+}

--- a/test/src/Tests/Service/DoctrineHydratorFactoryTest.php
+++ b/test/src/Tests/Service/DoctrineHydratorFactoryTest.php
@@ -2,6 +2,7 @@
 
 namespace PhproTest\DoctrineHydrationModule\Tests\Service;
 
+use PhproTest\DoctrineHydrationModule\Hydrator\CustomBuildHydratorFactory;
 use Phpro\DoctrineHydrationModule\Service\DoctrineHydratorFactory;
 use Zend\ServiceManager\ServiceManager;
 use Zend\Hydrator\HydratorPluginManager;
@@ -183,6 +184,25 @@ class DoctrineHydratorFactoryTest extends \PHPUnit_Framework_TestCase
         $this->serviceManager->setService('config', $this->serviceConfig);
 
         $this->serviceManager->setService('custom.hydrator', $this->getMock('Zend\Hydrator\ArraySerializable'));
+
+        $hydrator = $this->createOrmHydrator();
+
+        $this->assertInstanceOf('Zend\Hydrator\ArraySerializable', $hydrator->getHydrateService());
+        $this->assertInstanceOf('Zend\Hydrator\ArraySerializable', $hydrator->getExtractService());
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_be_possible_to_configure_a_custom_hydrator_as_factory()
+    {
+        $this->serviceConfig['doctrine-hydrator']['custom-hydrator']['hydrator'] = 'custom.build.hydrator';
+        $this->serviceManager->setService('config', $this->serviceConfig);
+
+        $this->serviceManager->setFactory(
+            'custom.build.hydrator',
+            new CustomBuildHydratorFactory()
+        );
 
         $hydrator = $this->createOrmHydrator();
 


### PR DESCRIPTION
Instead of using `->get` from the service manager use `->build` and allow custom hydrators to be built by an abstract factory.

I would like to replace all my use of DoctrineObject hydrator from DoctrineModule but in order to do that I need to create individual hydrators and even these will not have the current  hydrator configuration.

This simple change gives a lot of benefit and I ask that you post a new version with this asap.