### PR TITLE
Added support for DoctrineModule 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: php
 
 cache:
@@ -16,6 +15,12 @@ matrix:
     - php: 5.6
       env: DEPENDENCIES='low' MONGO_VERSION=stable
     - php: 7.0
+      env: ADAPTER_VERSION="^1.0.0" MONGODB_VERSION=stable
+    - php: 7.1
+      env: ADAPTER_VERSION="^1.0.0" MONGODB_VERSION=stable
+    - php: 7.2
+      env: ADAPTER_VERSION="^1.0.0" MONGODB_VERSION=stable
+    - php: 7.3
       env: ADAPTER_VERSION="^1.0.0" MONGODB_VERSION=stable
 
 before_install:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Make sure to commit on the correct branch if you want your changes to get merged
 
 ## Add to composer.json
 ```
-composer require phpro/zf-doctrine-hydration-module:^3.0
+composer require phpro/zf-doctrine-hydration-module
 ```
 
 ## Add to application config

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "license": "MIT",
   "description": "Doctrine hydrators for ZF2 and ZF3",
   "keywords": [
-    "zf2",
+    "zf",
     "doctrine",
     "hydrator"
   ],
@@ -21,18 +21,17 @@
   "require": {
     "php": "^5.6 || ^7.0",
     "doctrine/common": "^2.6.1",
+    "doctrine/doctrine-module": "^1.2 || ^2.1.7",
+    "doctrine/instantiator": "^1.0.5",
     "zendframework/zend-servicemanager": "^3.3.2",
     "zendframework/zend-hydrator": "^1.1 || ^2.2.1",
-    "zendframework/zend-modulemanager": "^2.7.2",
-    "api-skeletons/zf-doctrine-module-zend-hydrator": "^1.0",
-    "doctrine/doctrine-module": "^1.2",
-    "doctrine/instantiator": "^1.0.5"
+    "zendframework/zend-modulemanager": "^2.7.2"
   },
   "require-dev": {
     "fabpot/PHP-CS-Fixer": "^1.11.6",
-    "phpunit/phpunit": "^4.8",
-    "doctrine/doctrine-orm-module": "^1.1",
-    "doctrine/doctrine-mongo-odm-module": "^0.11",
+    "phpunit/phpunit": "^5.7.27",
+    "doctrine/doctrine-orm-module": "^1.1 || ^2.1.2",
+    "doctrine/doctrine-mongo-odm-module": "^0.11 || ^1.0",
     "doctrine/mongodb-odm": "^1.1",
     "phpro/grumphp": "^0.9.1"
   },

--- a/test/src/Tests/Hydrator/DoctrineHydratorTest.php
+++ b/test/src/Tests/Hydrator/DoctrineHydratorTest.php
@@ -3,11 +3,12 @@
 namespace PhproTest\DoctrineHydrationModule\Tests\Hydrator;
 
 use Phpro\DoctrineHydrationModule\Hydrator\DoctrineHydrator;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class DoctrineHydratorTest.
  */
-class DoctrineHydratorTest extends \PHPUnit_Framework_TestCase
+class DoctrineHydratorTest extends TestCase
 {
     /**
      * @param null $hydrateService
@@ -17,8 +18,8 @@ class DoctrineHydratorTest extends \PHPUnit_Framework_TestCase
      */
     protected function createHydrator($hydrateService = null, $extractService = null)
     {
-        $hydrateService = $hydrateService ? $hydrateService : $this->getMock('Zend\Hydrator\HydratorInterface');
-        $extractService = $extractService ? $extractService : $this->getMock('Zend\Hydrator\HydratorInterface');
+        $hydrateService = $hydrateService ? $hydrateService : $this->getMockBuilder('Zend\Hydrator\HydratorInterface')->getMock();
+        $extractService = $extractService ? $extractService : $this->getMockBuilder('Zend\Hydrator\HydratorInterface')->getMock();
 
         return new DoctrineHydrator($extractService, $hydrateService);
     }
@@ -57,7 +58,7 @@ class DoctrineHydratorTest extends \PHPUnit_Framework_TestCase
     {
         $object = new \stdClass();
         $extracted = array('extracted' => true);
-        $extractService = $this->getMock('Zend\Hydrator\HydratorInterface');
+        $extractService = $this->getMockBuilder('Zend\Hydrator\HydratorInterface')->getMock();
         $extractService
             ->expects($this->any())
             ->method('extract')
@@ -77,7 +78,7 @@ class DoctrineHydratorTest extends \PHPUnit_Framework_TestCase
         $object = new \stdClass();
         $data = array('field' => 'value');
 
-        $hydrateService = $this->getMock('Zend\Hydrator\HydratorInterface');
+        $hydrateService = $this->getMockBuilder('Zend\Hydrator\HydratorInterface')->getMock();
         $hydrateService
             ->expects($this->any())
             ->method('hydrate')
@@ -98,7 +99,7 @@ class DoctrineHydratorTest extends \PHPUnit_Framework_TestCase
         $object = new \stdClass();
         $data = array('field' => 'value');
 
-        $hydrateService = $this->getMock('Doctrine\ODM\MongoDB\Hydrator\HydratorInterface');
+        $hydrateService = $this->getMockBuilder('Doctrine\ODM\MongoDB\Hydrator\HydratorInterface')->getMock();
         $hydrateService
             ->expects($this->any())
             ->method('hydrate')

--- a/test/src/Tests/Hydrator/ODM/MongoDB/DoctrineObjectTest.php
+++ b/test/src/Tests/Hydrator/ODM/MongoDB/DoctrineObjectTest.php
@@ -22,7 +22,9 @@ class DoctrineObjectTest extends BaseTest
      */
     protected function createHydrator($objectManager = null)
     {
-        $objectManager = $objectManager ? $objectManager : $this->getMock('Doctrine\ODM\MongoDB\DocumentManager', array(), array(), '', false);
+        $objectManager = $objectManager ? $objectManager : $this->getMockBuilder('Doctrine\ODM\MongoDB\DocumentManager')
+            ->disableOriginalConstructor()
+            ->getMock();
         $hydrator = new DoctrineObject($objectManager);
 
         return $hydrator;

--- a/test/src/Tests/Hydrator/ODM/MongoDB/Strategy/DateTimeFieldTest.php
+++ b/test/src/Tests/Hydrator/ODM/MongoDB/Strategy/DateTimeFieldTest.php
@@ -3,11 +3,12 @@
 namespace PhproTest\DoctrineHydrationModule\Tests\Hydrator\ODM\MongoDB\Strategy;
 
 use Phpro\DoctrineHydrationModule\Hydrator\ODM\MongoDB\Strategy\DateTimeField;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class DateTimeFieldTest.
  */
-class DateTimeFieldTest extends \PHPUnit_Framework_TestCase
+class DateTimeFieldTest extends TestCase
 {
     /**
      * @param bool $isTimestamp

--- a/test/src/Tests/ModuleTest.php
+++ b/test/src/Tests/ModuleTest.php
@@ -3,11 +3,12 @@
 namespace PhproTest\DoctrineHydrationModule\Tests;
 
 use Phpro\DoctrineHydrationModule\Module;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ModuleTest.
  */
-class ModuleTest extends \PHPUnit_Framework_TestCase
+class ModuleTest extends TestCase
 {
     /**
      * @test

--- a/test/src/Tests/Service/DoctrineHydratorFactoryTest.php
+++ b/test/src/Tests/Service/DoctrineHydratorFactoryTest.php
@@ -4,10 +4,11 @@ namespace PhproTest\DoctrineHydrationModule\Tests\Service;
 
 use PhproTest\DoctrineHydrationModule\Hydrator\CustomBuildHydratorFactory;
 use Phpro\DoctrineHydrationModule\Service\DoctrineHydratorFactory;
+use PHPUnit\Framework\TestCase;
 use Zend\ServiceManager\ServiceManager;
 use Zend\Hydrator\HydratorPluginManager;
 
-class DoctrineHydratorFactoryTest extends \PHPUnit_Framework_TestCase
+class DoctrineHydratorFactoryTest extends TestCase
 {
     /**
      * @var array
@@ -34,9 +35,18 @@ class DoctrineHydratorFactoryTest extends \PHPUnit_Framework_TestCase
         $this->serviceManager = new ServiceManager();
         $this->serviceManager->setAllowOverride(true);
         $this->serviceManager->setService('config', $this->serviceConfig);
-        $this->serviceManager->setService('custom.strategy', $this->getMock('Zend\Hydrator\Strategy\StrategyInterface'));
-        $this->serviceManager->setService('custom.filter', $this->getMock('Zend\Hydrator\Filter\FilterInterface'));
-        $this->serviceManager->setService('custom.naming_strategy', $this->getMock('Zend\Hydrator\NamingStrategy\NamingStrategyInterface'));
+        $this->serviceManager->setService(
+            'custom.strategy',
+            $this->getMockBuilder('Zend\Hydrator\Strategy\StrategyInterface')->getMock()
+        );
+        $this->serviceManager->setService(
+            'custom.filter',
+            $this->getMockBuilder('Zend\Hydrator\Filter\FilterInterface')->getMock()
+        );
+        $this->serviceManager->setService(
+            'custom.naming_strategy',
+            $this->getMockBuilder('Zend\Hydrator\NamingStrategy\NamingStrategyInterface')->getMock()
+        );
 
         $this->hydratorManager = $this->getMockBuilder(HydratorPluginManager::class)
             ->disableOriginalConstructor()
@@ -55,7 +65,9 @@ class DoctrineHydratorFactoryTest extends \PHPUnit_Framework_TestCase
      */
     protected function stubObjectManager($objectManagerClass)
     {
-        $objectManager = $this->getMock($objectManagerClass, array(), array(), '', false);
+        $objectManager = $this->getMockBuilder($objectManagerClass)
+            ->disableOriginalConstructor()
+            ->getMock();
         $this->serviceManager->setService('doctrine.default.object-manager', $objectManager);
 
         return $objectManager;
@@ -153,8 +165,10 @@ class DoctrineHydratorFactoryTest extends \PHPUnit_Framework_TestCase
         $this->serviceManager->setService('config', $this->serviceConfig);
         $objectManager = $this->stubObjectManager('Doctrine\ODM\MongoDb\DocumentManager');
 
-        $hydratorFactory = $this->getMock('Doctrine\ODM\MongoDB\Hydrator\HydratorFactory', array(), array(), '', false);
-        $generatedHydrator = $this->getMock('Doctrine\ODM\MongoDB\Hydrator\HydratorInterface');
+        $hydratorFactory = $this->getMockBuilder('Doctrine\ODM\MongoDB\Hydrator\HydratorFactory')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $generatedHydrator = $this->getMockBuilder('Doctrine\ODM\MongoDB\Hydrator\HydratorInterface')->getMock();
 
         $objectManager
             ->expects($this->any())
@@ -183,7 +197,10 @@ class DoctrineHydratorFactoryTest extends \PHPUnit_Framework_TestCase
         $this->serviceConfig['doctrine-hydrator']['custom-hydrator']['hydrator'] = 'custom.hydrator';
         $this->serviceManager->setService('config', $this->serviceConfig);
 
-        $this->serviceManager->setService('custom.hydrator', $this->getMock('Zend\Hydrator\ArraySerializable'));
+        $this->serviceManager->setService(
+            'custom.hydrator',
+            $this->getMockBuilder('Zend\Hydrator\ArraySerializable')->getMock()
+        );
 
         $hydrator = $this->createOrmHydrator();
 


### PR DESCRIPTION
Replaces #38 

- added support for DoctrineModule v2.1
- run tests on PHP 7.1/7.2/7.3
- updated to PHPUnit v5.7

No BC Break, so it can be released as 4.1.